### PR TITLE
Fix issue num steps DDP

### DIFF
--- a/nerv/training/method.py
+++ b/nerv/training/method.py
@@ -245,7 +245,7 @@ class BaseMethod(nn.Module):
         train_steps = (
             len(self.train_loader.sampler) -
             self.train_loader.sampler.real_counter(self.iter_train_loader)
-        ) // (self.params.train_batch_size * self.gpus)
+        ) // self.params.train_batch_size
         tqdm_desc = f'Train epoch {self.epoch}, rank {self.local_rank}'
         with tqdm(total=train_steps, desc=tqdm_desc) as t:
             t1 = time.time()


### PR DESCRIPTION
The computed number of steps per gpu is wrong in DDP mode.  As the sampler already divides the instances over the gpus and the batch size is also divided per gpu in the config file, it is not necessary to multiply it back to the number of gpus. The number of training step is computer for each gpu.

Related issue :
https://github.com/pairlab/SlotFormer/issues/11